### PR TITLE
Prevent swiping while sliding

### DIFF
--- a/carousel-swipe.js
+++ b/carousel-swipe.js
@@ -27,7 +27,7 @@
       .on('touchstart',        $.proxy(this.touchstart,this))
       .on('touchmove',         $.proxy(this.touchmove,this))
       .on('touchend',          $.proxy(this.touchend,this))
-      .on('slide.bs.carousel', $.proxy(this.sliding, this))
+      .on('slide.bs.carousel', $.proxy(this.startSliding, this))
       .on('slid.bs.carousel',  $.proxy(this.stopSliding, this))
   }
 
@@ -35,7 +35,7 @@
     swipe: 50 // percent per second
   }
 
-  CarouselSwipe.prototype.sliding = function() {
+  CarouselSwipe.prototype.startSliding = function() {
     this.sliding = true
   }
 
@@ -55,7 +55,7 @@
   }
 
   CarouselSwipe.prototype.touchmove = function(e) {
-    if (this.sliding || !this.options.swipe) return;
+    if (this.sliding || !this.options.swipe || !this.startTime) return;
     var touch = e.originalEvent.touches ? e.originalEvent.touches[0] : e
     var dx = touch.pageX - this.startX
     var dy = touch.pageY - this.startY
@@ -72,7 +72,7 @@
   }
 
   CarouselSwipe.prototype.touchend = function(e) {
-    if (this.sliding || !this.options.swipe) return;
+    if (this.sliding || !this.options.swipe || !this.startTime) return;
     if (!this.$active) return; // nothing moved
     var all = $()
       .add(this.$active).add(this.$prev).add(this.$next)
@@ -95,6 +95,7 @@
     all.css('transform', '')
     this.cycling && this.carousel.cycle()
     this.$active = null // reset the active element
+    this.startTime = null
   }
 
   CarouselSwipe.prototype.swipe = function(percent) {


### PR DESCRIPTION
I'm assuming this is what was intended by tracking the `sliding` flag, which is not getting updated due to the naming collision between flag and event handler.

If interested, I also added the following for my own use, where transitions maintain the velocity of a swipe:

```diff
     var dt = (e.timeStamp - this.startTime) / 1000
     var speed = Math.abs(this.dx / dt) // percent-per-second
+    var duration = this.$active.css('transition-duration').slice(0, -1) // seconds
+    duration = Math.min(100 / speed, duration);
+    all
+      .css('transition-timing-function', 'ease-out')
+      .css('transition-duration', duration + 's')
     if (this.dx > 40 || (this.dx > 0 && speed > this.options.swipe)) {
       this.carousel.prev()
     } else if (this.dx < -40 || (this.dx < 0 && speed > this.options.swipe)) {
@@ -89,12 +94,20 @@
         .one($.support.transition.end, function () {
           all.removeClass('prev next')
         })
-      .emulateTransitionEnd(this.$active.css('transition-duration').slice(0, -1) * 1000)
+      .emulateTransitionEnd(duration * 1000)
     }

+    this.$active
+      .one($.support.transition.end, function () {
+        all.css('transition-timing-function', '')
+          .css('transition-duration', '')
+      })
+    .emulateTransitionEnd(duration * 1000)
```